### PR TITLE
Make Docker container monitoring work

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -5,3 +5,7 @@
     name: newrelic-sysmond
     state: "{{ newrelic_service_state }}"
     enabled: "{{ newrelic_service_enabled }}"
+
+- name: Add newrelic user to docker group
+  user: name=newrelic append=yes groups=docker
+  when: not newrelic_disable_docker


### PR DESCRIPTION
per the docs here: https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/enabling-new-relic-servers-docker

need to add the `newrelic` user to `docker` group, then it works
